### PR TITLE
fix badge url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-[![Actions Status](https://github.com/clinic-dot-com/clinic/workflows/rubyonrails/badge.svg)](https://github.com/clinic-dot-com/clinic/actions)
+[![Actions Status](https://github.com/clinic-dot-com/clinic/workflows/Ruby%20on%20Rails%20CI/badge.svg)](https://github.com/clinic-dot-com/clinic/actions)
 
 The clinic management system
 


### PR DESCRIPTION
### Description

fix ci badge, so instead of using workflow file name the "workflow name" should be used