### PR TITLE
add annotate gem & annotate existed model & add workflow

### DIFF
--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -1,0 +1,20 @@
+---
+name: annotate
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  annotate:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899
+        with:
+          bundler-cache: true
+      - name: Run annotate and exit(1) if something is unannotated
+        run: bundle exec annotate --frozen

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'annotate'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -314,6 +317,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   brakeman
   bundle-audit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,24 @@
 # frozen_string_literal: true
 
-##
-# The primary model used for authentication
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  encrypted_password     :string           default(""), not null
+#  phone                  :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :string           not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_phone                 (phone) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+if Rails.env.development?
+  require 'annotate'
+
+  DEFAULT_CONFIGS = {
+    active_admin: 'false',
+    additional_file_patterns: [],
+    routes: 'false',
+    models: 'true',
+    position_in_routes: 'before',
+    position_in_class: 'before',
+    pos2ition_in_test: 'before',
+    position_in_fixture: 'before',
+    position_in_factory: 'before',
+    position_in_serializer: 'before',
+    show_foreign_keys: 'true',
+    show_complete_foreign_keys: 'false',
+    show_indexes: 'true',
+    simple_indexes: 'false',
+    model_dir: 'app/models',
+    root_dir: '',
+    include_version: 'false',
+    require: '',
+    exclude_tests: 'false',
+    exclude_fixtures: 'false',
+    exclude_factories: 'false',
+    exclude_serializers: 'false',
+    exclude_scaffolds: 'true',
+    exclude_controllers: 'true',
+    exclude_helpers: 'true',
+    exclude_sti_subclasses: 'false',
+    ignore_model_sub_dir: 'false',
+    ignore_columns: nil,
+    ignore_routes: nil,
+    ignore_unknown_models: 'false',
+    hide_limit_column_types: 'integer,bigint,boolean',
+    hide_default_column_types: 'json,jsonb,hstore',
+    skip_on_db_migrate: 'false',
+    format_bare: 'true',
+    format_rdoc: 'false',
+    format_yard: 'false',
+    format_markdown: 'false',
+    sort: 'false',
+    force: 'false',
+    frozen: 'false',
+    classified_sort: 'true',
+    trace: 'false',
+    wrapper_open: nil,
+    wrapper_close: nil,
+    with_comment: 'true'
+  }.freeze
+
+  task :set_annotation_options do
+    Annotate.set_defaults(DEFAULT_CONFIGS)
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
### Description

- Add annotate gem to add missing comments on top of each ActiveRecord model to see what attributes contain each of them.
- Add workflow on a case when the maintainer added some new model or new unit test
  and then forgot to add annotation to them in such a case the annotate GitHub workflow will fail


### Additional links

closes #22

### Additional info

Note that the annotation process is performed automatically when you execute migrations locally on your computer