### PR TITLE
remove build info from footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,11 +14,5 @@
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
     <%= yield %>
-    <% current_tag = `git describe --tags` %>
-    <% commit_version = `git rev-parse --short HEAD` %>
-    <footer class="build-info">
-      <span>Build information: <%=  "version: #{current_tag}, commit: #{commit_version}," %></span>
-      <%= link_to('Status page', 'https://clinic.betteruptime.com') %>
-    </footer>
   </body>
 </html>

--- a/spec/system/root_system_spec.rb
+++ b/spec/system/root_system_spec.rb
@@ -12,10 +12,5 @@ RSpec.describe 'Root path' do
       expect(page).to have_selector 'h1', exact_text: 'Home#index'
       expect(page).to have_current_path root_path
     end
-
-    it 'should display additional info about build' do
-      expect(page).to have_selector '.build-info', text: 'Build information: version:'
-      expect(page).to have_link 'Status page', href: 'https://clinic.betteruptime.com'
-    end
   end
 end


### PR DESCRIPTION
### Description

remove build info from a footer section because in production we have docker ignore file that ignore .git folder therefore we can't determinate what commit version is used